### PR TITLE
fix wallpaper task

### DIFF
--- a/roles/arch2disk/tasks/main.yml
+++ b/roles/arch2disk/tasks/main.yml
@@ -72,7 +72,7 @@
     efibootmgr efitools
     linux linux-firmware sudo
     openssh networkmanager
-    python pyalpm
+    python pyalpm python-psutil
     dosfstools btrfs-progs
     --noprogressbar
   args:


### PR DESCRIPTION
this should fix the error
```

The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_dconf_payload_d_tro64o/ansible_dconf_payload.zip/ansible_collections/community/general/plugins/modules/dconf.py", line 125, in <module>
ModuleNotFoundError: No module named 'psutil'
fatal: [archiso]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "key": "/org/gnome/desktop/background",
            "state": "present",
            "value": "['picture-uri', 'file:///usr/local/share/backgrounds/wallpaper.jpg']"
        }
    },
    "msg": "Failed to import the required Python library (psutil) on 173f8d0401's Python /usr/bin/python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"
}
```
